### PR TITLE
Migrate JSON to EJSON

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "webpack": "^1.10.1"
   },
   "dependencies": {
+    "ejson": "^2.1.2",
     "wolfy87-eventemitter": "^4.2.11"
   }
 }

--- a/src/socket.js
+++ b/src/socket.js
@@ -1,4 +1,5 @@
 import EventEmitter from "wolfy87-eventemitter";
+import EJSON from "ejson";
 
 export default class Socket extends EventEmitter {
 
@@ -16,10 +17,10 @@ export default class Socket extends EventEmitter {
     }
 
     send (object) {
-        var message = JSON.stringify(object);
+        var message = EJSON.stringify(object);
         this.rawSocket.send(message);
         // Emit a copy of the object, as the listener might mutate it.
-        this.emit("message:out", JSON.parse(message));
+        this.emit("message:out", EJSON.parse(message));
     }
 
     connect () {
@@ -38,7 +39,7 @@ export default class Socket extends EventEmitter {
         this.rawSocket.onmessage = (message) => {
             var object;
             try {
-                object = JSON.parse(message.data);
+                object = EJSON.parse(message.data);
             } catch (ignore) {
                 // Simply ignore the malformed message and return
                 return;

--- a/test/socket.js
+++ b/test/socket.js
@@ -125,6 +125,16 @@ describe("`Socket` class", function () {
             EJSON.parse.restore();
         });
 
+        it("parses correctly EJSON-specific data types", function () {
+            var socket = new Socket(SocketConstructorMock);
+            var testDate = new Date();
+            sinon.stub(EJSON, "parse");
+            socket.connect();
+            socket.rawSocket.onmessage({data: testDate});
+            expect(EJSON.parse).to.have.been.calledWith(testDate);
+            EJSON.parse.restore();
+        });
+
         it("emits `message:in` events", function () {
             var socket = new Socket(SocketConstructorMock);
             socket.emit = sinon.spy();

--- a/test/socket.js
+++ b/test/socket.js
@@ -5,6 +5,7 @@ import sinonChai from "sinon-chai";
 chai.use(sinonChai);
 
 import Socket from "../src/socket";
+import EJSON from "ejson";
 
 class SocketConstructorMock {}
 
@@ -29,7 +30,7 @@ describe("`Socket` class", function () {
             var object = {
                 a: "a"
             };
-            var expectedMessage = JSON.stringify(object);
+            var expectedMessage = EJSON.stringify(object);
             socket.send(object);
             expect(socket.rawSocket.send).to.have.been.calledWith(expectedMessage);
         });
@@ -109,26 +110,26 @@ describe("`Socket` class", function () {
 
         it("parses message data into an object", function () {
             var socket = new Socket(SocketConstructorMock);
-            sinon.stub(JSON, "parse");
+            sinon.stub(EJSON, "parse");
             socket.connect();
             socket.rawSocket.onmessage({data: "message"});
-            expect(JSON.parse).to.have.been.calledWith("message");
-            JSON.parse.restore();
+            expect(EJSON.parse).to.have.been.calledWith("message");
+            EJSON.parse.restore();
         });
 
         it("ignores malformed messages", function () {
             var socket = new Socket(SocketConstructorMock);
-            sinon.stub(JSON, "parse").throws();
+            sinon.stub(EJSON, "parse").throws();
             socket.connect();
             expect(socket.rawSocket.onmessage).not.to.throw();
-            JSON.parse.restore();
+            EJSON.parse.restore();
         });
 
         it("emits `message:in` events", function () {
             var socket = new Socket(SocketConstructorMock);
             socket.emit = sinon.spy();
             socket.connect();
-            socket.rawSocket.onmessage({data: JSON.stringify({a: "a"})});
+            socket.rawSocket.onmessage({data: EJSON.stringify({a: "a"})});
             expect(socket.emit).to.have.been.calledWith("message:in", {a: "a"});
         });
 


### PR DESCRIPTION
Meteor uses EJSON. Some packages, like CollectionFS, take advantage of this.

Things like `Date` type are handled differently than with pure JSON, and this should solve issues like this one: https://github.com/mondora/asteroid/issues/78