### PR TITLE
allow subscription id to be specified

### DIFF
--- a/src/ddp.js
+++ b/src/ddp.js
@@ -110,8 +110,8 @@ export default class DDP extends EventEmitter {
         return id;
     }
 
-    sub (name, params) {
-        const id = uniqueId();
+    sub (name, params, id = null) {
+        id || (id = uniqueId());
         this.messageQueue.push({
             msg: "sub",
             id: id,

--- a/test/unit/ddp.js
+++ b/test/unit/ddp.js
@@ -118,6 +118,22 @@ describe("`DDP` class", () => {
             expect(id).to.be.a("string");
         });
 
+        it("generates unique id when not specified", () => {
+            const ddp = new DDP(options);
+            var ids = [];
+            ids.push(ddp.sub("echo", [ 0 ]));
+            ids.push(ddp.sub("echo", [ 0 ]));
+            expect(ids[0]).to.be.a("string");
+            expect(ids[1]).to.be.a("string");
+            expect(ids[0]).not.to.equal(ids[1]);
+        });
+
+        it("allows manually specifying sub's id", () => {
+            const ddp = new DDP(options);
+            const subId = ddp.sub("echo", [ 0 ], '12345');
+            expect(subId).to.equal('12345');
+        });
+
     });
 
     describe("`unsub` method", () => {

--- a/test/unit/ddp.js
+++ b/test/unit/ddp.js
@@ -130,8 +130,8 @@ describe("`DDP` class", () => {
 
         it("allows manually specifying sub's id", () => {
             const ddp = new DDP(options);
-            const subId = ddp.sub("echo", [ 0 ], '12345');
-            expect(subId).to.equal('12345');
+            const subId = ddp.sub("echo", [ 0 ], "12345");
+            expect(subId).to.equal("12345");
         });
 
     });


### PR DESCRIPTION
In our use case, we wanted to be able to specify subscription id.

I've added an optional third `id` option to `sub` method.