### PR TITLE
Updated wolfy87-eventemitter to 5.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,6 @@
     "sinon-chai": "^2.8.0"
   },
   "dependencies": {
-    "wolfy87-eventemitter": "^4.3.0"
+    "wolfy87-eventemitter": "^5.1.0"
   }
 }


### PR DESCRIPTION
5.x contains critical fix - "EventEmitter.js?38d3:22 Uncaught TypeError: Cannot read property 'EventEmitter' of undefined"