### PR TITLE
Add sessionId to this

### DIFF
--- a/src/ddp.js
+++ b/src/ddp.js
@@ -68,6 +68,7 @@ export default class DDP extends EventEmitter {
         this.socket.on("message:in", message => {
             if (message.msg === "connected") {
                 this.status = "connected";
+                this.sessionId = message.session;
                 this.messageQueue.process();
                 this.emit("connected");
             } else if (message.msg === "ping") {


### PR DESCRIPTION
Meteor provides a connection id in the server. Sometimes we may need access to it on the client. Thus I added it.